### PR TITLE
fixForNewStateSpecsAdoptation

### DIFF
--- a/ObjectTravel-Tests.package/ObjectTravelerTests.class/instance/testTraverseBlockClosure.st
+++ b/ObjectTravel-Tests.package/ObjectTravelerTests.class/instance/testTraverseBlockClosure.st
@@ -4,11 +4,12 @@ testTraverseBlockClosure
 	| traveler block refs |
 	block := [Point x: 1 y: 10].
 	traveler := ObjectTraveler on: block.
-	traveler skipAll: {block outerContext sender. traveler. traveler class. self class. Point }.
+	traveler skipAll: {
+		block outerContext sender. traveler. traveler class. self class. Point. Identical}.
 
 	refs := traveler collectReferences.
 	refs should include: block outerContext.
 	refs should include: (Identical to: block).
 	refs should include: thisContext method.
 	refs should include: self.
-	refs size should be < 40
+	refs size should be < 42


### PR DESCRIPTION
fix traverse block test. (With Identical class reference the number of references are grow a bit)