### PR TITLE
Fix FullBlockClosure traversal for Pharo 9 compatibility

### DIFF
--- a/ObjectTravel-Tests/ObjectTravelerTests.class.st
+++ b/ObjectTravel-Tests/ObjectTravelerTests.class.st
@@ -370,7 +370,7 @@ ObjectTravelerTests >> testTraverseBlockClosure [
 	refs should include: (Identical to: block).
 	refs should include: thisContext method.
 	refs should include: self.
-	refs size should be < 42
+	refs size should be < 46
 ]
 
 { #category : #tests }

--- a/ObjectTravel/CompiledCode.extension.st
+++ b/ObjectTravel/CompiledCode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #CompiledCode }
+
+{ #category : #'*ObjectTravel' }
+CompiledCode >> travelGuide [
+	^CompiledCodeTravelGuide
+
+]

--- a/ObjectTravel/CompiledCodeTravelGuide.class.st
+++ b/ObjectTravel/CompiledCodeTravelGuide.class.st
@@ -2,28 +2,28 @@
 I am special mirror to discover CompiledMethod references inside method literals
 "
 Class {
-	#name : #CompiledMethodTravelGuide,
+	#name : #CompiledCodeTravelGuide,
 	#superclass : #ObjectTravelGuide,
-	#category : 'ObjectTravel'
+	#category : #ObjectTravel
 }
 
 { #category : #navigation }
-CompiledMethodTravelGuide class >> isNode: aCompiledMethod hasLastReferenceAt: referenceIndex [
+CompiledCodeTravelGuide class >> isNode: aCompiledMethod hasLastReferenceAt: referenceIndex [
 	^referenceIndex >= aCompiledMethod numLiterals
 ]
 
 { #category : #navigation }
-CompiledMethodTravelGuide class >> isNodeEmpty: aCompiledMethod [
+CompiledCodeTravelGuide class >> isNodeEmpty: aCompiledMethod [
 	^aCompiledMethod numLiterals = 0
 ]
 
 { #category : #navigation }
-CompiledMethodTravelGuide class >> referenceOf: aCompiledMethod atIndex: referenceIndex [
+CompiledCodeTravelGuide class >> referenceOf: aCompiledMethod atIndex: referenceIndex [
 	^aCompiledMethod literalAt: referenceIndex 
 ]
 
 { #category : #operations }
-CompiledMethodTravelGuide class >> replaceReferenceOf: aCompiledMethod at: referenceIndex with: replacementObject [
+CompiledCodeTravelGuide class >> replaceReferenceOf: aCompiledMethod at: referenceIndex with: replacementObject [
 
 	aCompiledMethod literalAt: referenceIndex put: replacementObject 
 ]

--- a/ObjectTravel/CompiledMethod.extension.st
+++ b/ObjectTravel/CompiledMethod.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #CompiledMethod }
-
-{ #category : #'*ObjectTravel' }
-CompiledMethod >> travelGuide [
-	^CompiledMethodTravelGuide
-
-]

--- a/ObjectTravel/ObjectTraveler.class.st
+++ b/ObjectTravel/ObjectTraveler.class.st
@@ -256,9 +256,10 @@ ObjectTraveler >> moveBreadthToNextReference [
 ObjectTraveler >> moveDepthToNextReference [
 
 	| newNode |
-	[[self wantsTraverseCurrentReference not and: [self moveBreadthToNextReference]] whileTrue.
-	
-	path size = 1 or: [self wantsTraverseCurrentReference]] whileFalse: [ 
+	[
+		[self wantsTraverseCurrentReference not and: [self moveBreadthToNextReference]] whileTrue.
+		path size = 1 or: [self wantsTraverseCurrentReference]
+	] whileFalse: [ 
 		self moveBackInDepth.
 		(currentReferenceIndex <= 0) ifTrue: [ 
 			"Depth way was forced by #atNextStepVisit: and now we need to continue walk breadth"


### PR DESCRIPTION
FullBlockClosure is supported by pushing CompiledMethod extensions into CompiledCode so that CompiledBlock becomes covered. Guide class is renamed accordingly 